### PR TITLE
withrottle changes

### DIFF
--- a/DCC.cpp
+++ b/DCC.cpp
@@ -95,6 +95,15 @@ bool DCC::getThrottleDirection(int cab) {
   return (speedTable[reg].speedCode & 0x80) !=0;
 }
 
+bool DCC::isThrottleInUse(int locoId) {
+  // return true if this loco address is already in table, false otherwise
+  int reg;
+  for (reg = 0; reg < MAX_LOCOS; reg++) {
+    if (speedTable[reg].loco == locoId) return true;
+  }
+  return false;
+}
+
 // Set function to value on or off
 void DCC::setFn( int cab, byte functionNumber, bool on) {
   if (cab<=0 || functionNumber>28) return;

--- a/DCC.h
+++ b/DCC.h
@@ -56,6 +56,7 @@ class DCC {
   static void setThrottle( uint16_t cab, uint8_t tSpeed, bool tDirection);
   static uint8_t getThrottleSpeed(int cab);
   static bool getThrottleDirection(int cab);
+  static bool isThrottleInUse(int cab);
   static void writeCVByteMain(int cab, int cv, byte bValue);
   static void writeCVBitMain(int cab, int cv, byte bNum, bool bValue);
   static void setFunction( int cab, byte fByte, byte eByte);

--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -147,16 +147,17 @@ void DCCEXParser::parse(Print * stream,  byte *com, bool blocking) {
     case '\0': return;    // filterCallback asked us to ignore 
     case 't':       // THROTTLE <t REGISTER CAB SPEED DIRECTION>
         {
+          if (p[1] == 0) break; // ignore requests for throttle address 0 (returns 'X')
           // Convert JMRI bizarre -1=emergency stop, 0-126 as speeds
           // to DCC 0=stop, 1= emergency stop, 2-127 speeds
           int tspeed=p[2];
           if (tspeed>126 || tspeed<-1) break; // invalid JMRI speed code
           if (tspeed<0) tspeed=1; // emergency stop DCC speed
           else if (tspeed>0) tspeed++; // map 1-126 -> 2-127
-        DCC::setThrottle(p[1],tspeed,p[3]);
-        // report speed 0 after emergency stop
-        StringFormatter::send(stream,F("<T %d %d %d>"), p[0], p[2]<0?0:p[2],p[3]);
-        return;
+          DCC::setThrottle(p[1],tspeed,p[3]);
+          // report speed 0 after emergency stop
+          StringFormatter::send(stream,F("<T %d %d %d>"), p[0], p[2]<0?0:p[2],p[3]);
+          return;
         }
     case 'f':       // FUNCTION <f CAB BYTE1 [BYTE2]>
         if (parsef(stream,params,p)) return;

--- a/WiThrottle.cpp
+++ b/WiThrottle.cpp
@@ -144,12 +144,12 @@ void WiThrottle::parse(Print & stream, byte * cmdx) {
                     case 'C': newstate=false; break;
                     case '2': newstate=!Turnout::isActive(id);                 
                 }
-		Turnout::activate(id,newstate);
+		            Turnout::activate(id,newstate);
                 StringFormatter::send(stream, F("PTA%c%d\n"),newstate?'4':'2',id );   
             }
             break;
        case 'N':  // Heartbeat (2)
-                StringFormatter::send(stream, F("*%d\n"),HEARTBEAT_TIMEOUT); // return timeout value
+            StringFormatter::send(stream, F("*%d\n"),HEARTBEAT_TIMEOUT); // return timeout value
             break;
        case 'M': // multithrottle
             multithrottle(stream, cmd); 
@@ -251,6 +251,7 @@ void WiThrottle::locoAction(Print & stream, byte* aval, char throttleChar, int c
               byte locospeed=getInt(aval+1);
               LOOPLOCOS(throttleChar, cab) {
                 DCC::setThrottle(myLocos[loco].cab,locospeed, DCC::getThrottleDirection(myLocos[loco].cab));
+                StringFormatter::send(stream,F("M%cA%c%d<;>V%d\n"), throttleChar, LorS(myLocos[loco].cab), myLocos[loco].cab, DCC::getThrottleSpeed(myLocos[loco].cab));
                 }
              } 
             break;
@@ -282,9 +283,10 @@ void WiThrottle::locoAction(Print & stream, byte* aval, char throttleChar, int c
             case 'R':
             { 
               bool forward=aval[1]!='0';
-                 LOOPLOCOS(throttleChar, cab) {              
-                    DCC::setThrottle(myLocos[loco].cab, DCC::getThrottleSpeed(myLocos[loco].cab), forward);
-                  }
+              LOOPLOCOS(throttleChar, cab) {              
+                DCC::setThrottle(myLocos[loco].cab, DCC::getThrottleSpeed(myLocos[loco].cab), forward);
+                StringFormatter::send(stream,F("M%cA%c%d<;>R%d\n"), throttleChar, LorS(myLocos[loco].cab), myLocos[loco].cab, DCC::getThrottleDirection(myLocos[loco].cab));
+              }
             }        
             break;      
             case 'X':

--- a/WiThrottle.h
+++ b/WiThrottle.h
@@ -36,7 +36,7 @@ class WiThrottle {
     ~WiThrottle();
    
       static const int MAX_MY_LOCO=10; //maximum number of locos assigned to a single client
-      static const int HEARTBEAT_TIMEOUT=3;// heartbeat at 3secs to provide messaging transport
+      static const int HEARTBEAT_TIMEOUT=2;// heartbeat at 2secs to provide messaging transport
       static WiThrottle* firstThrottle;
       static int getInt(byte * cmd);
       static int getLocoId(byte * cmd);

--- a/WiThrottle.h
+++ b/WiThrottle.h
@@ -36,7 +36,7 @@ class WiThrottle {
     ~WiThrottle();
    
       static const int MAX_MY_LOCO=10; //maximum number of locos assigned to a single client
-      static const int HEARTBEAT_TIMEOUT=4;// heartbeat at 4secs to provide messaging transport
+      static const int HEARTBEAT_TIMEOUT=3;// heartbeat at 3secs to provide messaging transport
       static WiThrottle* firstThrottle;
       static int getInt(byte * cmd);
       static int getLocoId(byte * cmd);

--- a/WiThrottle.h
+++ b/WiThrottle.h
@@ -17,7 +17,7 @@
  *  along with CommandStation.  If not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef WiThrottle_h
-#define WiTHrottle_h
+#define WiThrottle_h
 
 
 struct MYLOCO {
@@ -35,8 +35,8 @@ class WiThrottle {
     WiThrottle( int wifiClientId);
     ~WiThrottle();
    
-      static const int MAX_MY_LOCO=10;
-      static const int HEARTBEAT_TIMEOUT=10;// Timeout after 10 seconds, heartbeat at 5
+      static const int MAX_MY_LOCO=10; //maximum number of locos assigned to a single client
+      static const int HEARTBEAT_TIMEOUT=4;// heartbeat at 4secs to provide messaging transport
       static WiThrottle* firstThrottle;
       static int getInt(byte * cmd);
       static int getLocoId(byte * cmd);
@@ -46,7 +46,8 @@ class WiThrottle {
        
       MYLOCO myLocos[MAX_MY_LOCO];   
       bool heartBeatEnable;
-      byte  callState;  // 0=first, 1=second, 3=third, 4=fourth call... >4=rest. 
+      bool initSent=false;
+      bool turnoutListSent=false;
       unsigned long heartBeat;
       
      void multithrottle(Print & stream, byte * cmd);

--- a/WifiInterface.cpp
+++ b/WifiInterface.cpp
@@ -167,7 +167,7 @@ void WifiInterface::loop() {
       int ch=wifiStream->read();
       
       // echo the char to the diagnostic stream in escaped format
-      StringFormatter::printEscape(&DIAGSERIAL,ch); // DIAG in disguise
+//      StringFormatter::printEscape(&DIAGSERIAL,ch); // DIAG in disguise
       
       switch (loopstate) {
            case 0:  // looking for +IPD
@@ -208,7 +208,7 @@ void WifiInterface::loop() {
                   break;
                 } 
                 if (ch=='>'){
-                  DIAG(F("\n> [%e]\n"),buffer);
+//                  DIAG(F("\n> [%e]\n"),buffer);
                   wifiStream->print((char *) buffer);
                   loopTimeoutStart=millis();
                   loopstate=closeAfter?11:0;
@@ -232,7 +232,7 @@ void WifiInterface::loop() {
     // AT this point we have read an incoming message into the buffer
     streamer.print('\0'); // null the end of the buffer so we can treat it as a string
 
-    DIAG(F("\nWifiRead:%d:%e\n"),connectionId,buffer);
+    DIAG(F("\nWifi(%d)<-[%e]\n"),connectionId,buffer);
     streamer.setBufferContentPosition(0,0);  // reset write position to start of buffer
     // SIDE EFFECT WARNING::: 
     //  We know that parser will read the entire buffer before starting to write to it.
@@ -256,7 +256,7 @@ void WifiInterface::loop() {
     }
     // prepare to send reply 
     streamer.print('\0'); // null the end of the buffer so we can treat it as a string
-    DIAG(F("\nWiFiInterface reply c(%d) l(%d) [%e]\n"),connectionId,streamer.available()-1,buffer);
+    DIAG(F("WiFi(%d)->[%e] l(%d)\n"),connectionId,buffer,streamer.available()-1);
     StringFormatter::send(wifiStream,F("AT+CIPSEND=%d,%d\r\n"),connectionId,streamer.available()-1);
     loopTimeoutStart=millis();
     loopstate=10; // non-blocking loop waits for > before sending

--- a/WifiInterface.cpp
+++ b/WifiInterface.cpp
@@ -232,7 +232,7 @@ void WifiInterface::loop() {
     // AT this point we have read an incoming message into the buffer
     streamer.print('\0'); // null the end of the buffer so we can treat it as a string
 
-    DIAG(F("\nWifi(%d)<-[%e]\n"),connectionId,buffer);
+    DIAG(F("\n%d Wifi(%d)<-[%e]\n"),millis(),connectionId,buffer);
     streamer.setBufferContentPosition(0,0);  // reset write position to start of buffer
     // SIDE EFFECT WARNING::: 
     //  We know that parser will read the entire buffer before starting to write to it.
@@ -256,7 +256,7 @@ void WifiInterface::loop() {
     }
     // prepare to send reply 
     streamer.print('\0'); // null the end of the buffer so we can treat it as a string
-    DIAG(F("WiFi(%d)->[%e] l(%d)\n"),connectionId,buffer,streamer.available()-1);
+    DIAG(F("%d WiFi(%d)->[%e] l(%d)\n"),millis(),connectionId,buffer,streamer.available()-1);
     StringFormatter::send(wifiStream,F("AT+CIPSEND=%d,%d\r\n"),connectionId,streamer.available()-1);
     loopTimeoutStart=millis();
     loopstate=10; // non-blocking loop waits for > before sending


### PR DESCRIPTION
disallow acquire if address in use
return error on address 0 and mismatched L/S
move init string to 'HU' reply
some message format fixes
comment-out some DIAGs to show only in and out message traffic
return new speed and dir to client
drop any acquired locos on Q(uit)
reduce heartbeat to 2s (works best with next version of EngineDriver)
